### PR TITLE
Check for null or whitespace in addition to empty

### DIFF
--- a/OnlineAnnounceV2/OAMain.cs
+++ b/OnlineAnnounceV2/OAMain.cs
@@ -70,14 +70,14 @@ namespace OnlineAnnounceV2
 		private void OnLogin(PlayerPostLoginEventArgs args)
 		{
 			string greet = DB.SetInfo(args.Player);
-			if (greet != "")
+			if (!string.IsNullOrWhiteSpace(greet))
 				TSPlayer.All.SendMessage($"[{args.Player.User.Name}] " + greet, config.ToColor());
 		}
 
 		private void OnLogout(PlayerLogoutEventArgs args)
 		{
 			string leave = args.Player.GetData<OAInfo>(OAString).leave;
-			if (leave != "")
+			if (!string.IsNullOrWhiteSpace(leave))
 				TSPlayer.All.SendMessage($"[{args.Player.User.Name}] " + leave, config.ToColor());
 		}
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/5434547/21740883/d94d53b2-d4cf-11e6-9380-6ec4350f7409.png)

Because `string + null` becomes `string + string.Empty`